### PR TITLE
Feature/brp mock api

### DIFF
--- a/app/apps/cases/serializers.py
+++ b/app/apps/cases/serializers.py
@@ -138,3 +138,17 @@ class FineSerializer(serializers.Serializer):
 
 class FineListSerializer(serializers.Serializer):
     items = FineSerializer(required=True, many=True)
+
+
+class ResidentSerializer(serializers.Serializer):
+    geboortedatum = serializers.DateTimeField(required=True)
+    geslachtsaanduiding = serializers.ChoiceField(choices=("M", "V", "X"))
+    geslachtsnaam = serializers.CharField(required=True)
+    voorletters = serializers.CharField(required=True)
+    voornamen = serializers.CharField(required=True)
+    voorvoegsel_geslachtsnaam = serializers.CharField(required=False)
+    datum_begin_relatie_verblijadres = serializers.DateTimeField(required=True)
+
+
+class ResidentsSerializer(serializers.Serializer):
+    items = ResidentSerializer(required=True, many=True)

--- a/app/utils/api_queries_brp.py
+++ b/app/utils/api_queries_brp.py
@@ -4,6 +4,33 @@ from tenacity import after_log, retry, stop_after_attempt
 
 logger = logging.getLogger(__name__)
 
+# The following fields were presented in the example spreadsheet documentation, which should mirror the BRP API:
+# (TODO: remove this once the BRP API is up and its documentation is accessible )
+# A-nummer
+# BSN
+# sleutel paraplu
+# Onderzoek algemeen
+# Burgerlijke staat
+# Geboortedatum
+# Geboortelandcode
+# Geslachtsaanduiding
+# Geslachtsnaam
+# Voorletters
+# Voornamen
+# Voorvoegsel geslachtsnaam
+# Indicatie geheim
+# Landcode immigratie
+# Datum inschrijving
+# Gemeente code inschrijving
+# Aanduiding naamgebruik
+# Datum begin relatie verblijfadres
+# Aanduiding in onderzoek verblijfadres
+# Straatnaam
+# Huisnummer
+# Huisletter 0=n.v.t.
+# Huisnummertoevoeging 0=n.v.t.
+# Postcode
+
 
 @retry(stop=stop_after_attempt(3), after=after_log(logger, logging.ERROR))
 def get_brp(bag_id):

--- a/app/utils/api_queries_brp.py
+++ b/app/utils/api_queries_brp.py
@@ -1,0 +1,29 @@
+import logging
+
+from tenacity import after_log, retry, stop_after_attempt
+
+logger = logging.getLogger(__name__)
+
+
+@retry(stop=stop_after_attempt(3), after=after_log(logger, logging.ERROR))
+def get_brp(bag_id):
+    """ Returns BRP data"""
+    # TODO: Replace with actual request when BRP API is ready
+    return get_mock_brp()
+
+
+def get_mock_brp():
+    return {
+        "message": "mocked data",
+        "items": [
+            {
+                "geboortedatum": "1955-05-23T23:00:00Z",  # Note: This was marked as in spreadsheet in the following format: 19550523,
+                "geslachtsaanduiding": "V",
+                "geslachtsnaam": "Gouderinge",
+                "voorletters": "AC",
+                "voornamen": "Anne Carmen",
+                "voorvoegsel_geslachtsnaam": "van",
+                "datum_begin_relatie_verblijadres": "1992-05-26T23:00:00Z",  # Note: This was marked as in spreadsheet in the following format: 19920526,
+            }
+        ],
+    }


### PR DESCRIPTION
Stelt een API endpoint beschikbaar waarmee de bewoners op een adres van een lopende zaak opgevraagd kunnen worden.
Momenteel wordt er mock data teruggestuurd. Deze data is gemodeleerd naar de spreadsheet die als voorbeeld geleverd is.
Hiermee kan de frontend alvast aan de slag met BRP data.