### PR TITLE
Disabled open-zaak in deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,9 +65,9 @@ pipeline {
     REDIS_SOURCE = "./redis"
     REDIS_NAME = "zaken-redis"
 
-    OPEN_ZAAK_IMAGE_URL = "${DOCKER_REGISTRY_NO_PROTOCOL}/fixxx/zaken-open-zaak"
-    OPEN_ZAAK_SOURCE = "./open-zaak"
-    OPEN_ZAAK_NAME = "zaken-open-zaak"
+    // OPEN_ZAAK_IMAGE_URL = "${DOCKER_REGISTRY_NO_PROTOCOL}/fixxx/zaken-open-zaak"
+    // OPEN_ZAAK_SOURCE = "./open-zaak"
+    // OPEN_ZAAK_NAME = "zaken-open-zaak"
 
   }
 
@@ -86,7 +86,7 @@ pipeline {
         build_image(env.ZAKEN_IMAGE_URL, env.ZAKEN_SOURCE)
         build_image(env.CAMUNDA_IMAGE_URL, env.CAMUNDA_SOURCE)
         build_image(env.REDIS_IMAGE_URL, env.REDIS_SOURCE)
-        build_image(env.OPEN_ZAAK_IMAGE_URL, env.OPEN_ZAAK_SOURCE)
+        // build_image(env.OPEN_ZAAK_IMAGE_URL, env.OPEN_ZAAK_SOURCE)
       }
     }
 
@@ -99,7 +99,7 @@ pipeline {
         tag_and_deploy(env.ZAKEN_IMAGE_URL, env.ZAKEN_NAME, env.ACCEPTANCE)
         tag_and_deploy(env.CAMUNDA_IMAGE_URL, env.CAMUNDA_NAME, env.ACCEPTANCE)
         tag_and_deploy(env.REDIS_IMAGE_URL, env.REDIS_NAME, env.ACCEPTANCE)
-        tag_and_deploy(env.OPEN_ZAAK_IMAGE_URL, env.OPEN_ZAAK_NAME, env.ACCEPTANCE)
+        // tag_and_deploy(env.OPEN_ZAAK_IMAGE_URL, env.OPEN_ZAAK_NAME, env.ACCEPTANCE)
       }
     }
 
@@ -110,7 +110,7 @@ pipeline {
         tag_and_deploy(env.ZAKEN_IMAGE_URL, env.ZAKEN_NAME, env.PRODUCTION)
         tag_and_deploy(env.CAMUNDA_IMAGE_URL, env.CAMUNDA_NAME, env.PRODUCTION)
         tag_and_deploy(env.REDIS_IMAGE_URL, env.REDIS_NAME, env.PRODUCTION)
-        tag_and_deploy(env.OPEN_ZAAK_IMAGE_URL, env.OPEN_ZAAK_NAME, env.PRODUCTION)
+        // tag_and_deploy(env.OPEN_ZAAK_IMAGE_URL, env.OPEN_ZAAK_NAME, env.PRODUCTION)
       }
     }
   }
@@ -120,7 +120,7 @@ pipeline {
         remove_image(env.ZAKEN_IMAGE_URL)
         remove_image(env.CAMUNDA_IMAGE_URL)
         remove_image(env.REDIS_IMAGE_URL)
-        remove_image(env.OPEN_ZAAK_IMAGE_URL)
+        // remove_image(env.OPEN_ZAAK_IMAGE_URL)
     }
   }
 }


### PR DESCRIPTION
Temporarily disable the open zaak deploy (which is currently failing) in order to debug the Camunda deploy :)