### PR TITLE
Create users through the get_user_model function

### DIFF
--- a/app/apps/cases/views.py
+++ b/app/apps/cases/views.py
@@ -15,9 +15,9 @@ from apps.debriefings.mixins import DebriefingsMixin
 from apps.debriefings.models import Debriefing
 from apps.events.mixins import CaseEventsMixin
 from apps.users.auth_apps import TopKeyAuth
-from apps.users.models import User
 from apps.visits.models import Visit
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from keycloak_oidc.drf.permissions import IsInAuthorizedRealm
@@ -82,9 +82,10 @@ class CaseStateViewSet(ViewSet):
             case_state.users.clear()
             user_emails = data.get("user_emails", [])
             logger.info(f"Updating CaseState {len(user_emails)} users")
+            user_model = get_user_model()
 
             for user_email in user_emails:
-                user_object, _ = User.objects.get_or_create(email=user_email)
+                user_object, _ = user_model.objects.get_or_create(email=user_email)
                 case_state.users.add(user_object)
                 logger.info("Added user to CaseState")
 
@@ -138,18 +139,19 @@ class CaseViewSet(
                 address=address,
                 _quantity=7,
             )
-            user_1, _ = User.objects.get_or_create(
+            user_model = get_user_model()
+            user_1, _ = user_model.objects.get_or_create(
                 email="jake.gyllenhaal@example.com",
                 first_name="Jake",
                 last_name="Gyllenhaal",
             )
-            user_2, _ = User.objects.get_or_create(
+            user_2, _ = user_model.objects.get_or_create(
                 email="jessica.chastain@example.com",
                 first_name="Jessica",
                 last_name="Chastain",
             )
 
-            authors = User.objects.filter(id__in=[user_1.id, user_2.id])
+            authors = user_model.objects.filter(id__in=[user_1.id, user_2.id])
 
             for case in cases:
                 baker.make(

--- a/app/apps/debriefings/tests/tests_helpers.py
+++ b/app/apps/debriefings/tests/tests_helpers.py
@@ -1,6 +1,6 @@
 from apps.cases.models import Case
 from apps.debriefings.models import Debriefing
-from apps.users.models import User
+from django.contrib.auth import get_user_model
 
 
 class DebriefingTestMixin:
@@ -10,7 +10,8 @@ class DebriefingTestMixin:
 
     def create_user(self):
         USER_EMAIL = "foo@foo.com"
-        user = User.objects.create(email=USER_EMAIL)
+        user_model = get_user_model()
+        user = user_model.objects.create(email=USER_EMAIL)
         return user
 
     def create_debriefing(self):

--- a/app/apps/gateway/push/views.py
+++ b/app/apps/gateway/push/views.py
@@ -9,7 +9,7 @@ from apps.fines.legacy_const import STADIA_WITH_FINES
 from apps.fines.models import Fine
 from apps.gateway.push.serializers import PushSerializer
 from apps.users.auth_apps import TopKeyAuth
-from apps.users.models import User
+from django.contrib.auth import get_user_model
 from keycloak_oidc.drf.permissions import IsInAuthorizedRealm
 from rest_framework import viewsets
 from rest_framework.exceptions import APIException
@@ -96,9 +96,10 @@ class PushViewSet(viewsets.ViewSet):
 
     def create_users(self, user_emails):
         users = []
+        user_model = get_user_model()
 
         for user_email in user_emails:
-            user, _ = User.objects.get_or_create(email=user_email)
+            user, _ = user_model.objects.get_or_create(email=user_email)
             users.append(user)
 
         return users

--- a/app/apps/users/tests/tests_models.py
+++ b/app/apps/users/tests/tests_models.py
@@ -1,11 +1,12 @@
 """
 Tests for cases models
 """
-from apps.users.models import User
+from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.test import TestCase
 
 USER_EMAIL = "foo@foo.com"
+User = get_user_model()
 
 
 class UserModelTest(TestCase):

--- a/app/apps/visits/models.py
+++ b/app/apps/visits/models.py
@@ -1,6 +1,7 @@
 from apps.cases.models import Case
 from apps.events.models import CaseEvent, ModelEventEmitter
 from apps.users.models import User
+from django.contrib.auth import get_user_model
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
@@ -76,8 +77,10 @@ class Visit(ModelEventEmitter):
         self.notes = data["notes"]
         self.save()
 
+        user_model = get_user_model()
+
         for author in data["authors"]:
-            (user, _) = User.objects.get_or_create(email=author)
+            (user, _) = user_model.objects.get_or_create(email=author)
             self.authors.add(user)
 
         return self
@@ -94,8 +97,10 @@ class Visit(ModelEventEmitter):
         self.notes = data["notes"]
         self.save()
 
+        user_model = get_user_model()
+
         for author in data["authors"]:
-            (user, _) = User.objects.get_or_create(email=author)
+            (user, _) = user_model.objects.get_or_create(email=author)
             self.authors.add(user)
 
         return self

--- a/app/deploy/docker-entrypoint.development.sh
+++ b/app/deploy/docker-entrypoint.development.sh
@@ -21,7 +21,7 @@ echo Apply migrations
 python manage.py migrate --noinput
 
 # echo Create root user
-# python manage.py shell -c "from apps.users.models import User; User.objects.create_superuser('admin@admin.com', 'admin')"
+# python manage.py shell -c "from django.contrib.auth import get_user_model; get_user_model().objects.create_superuser('admin@admin.com', 'admin')"
 
 # opens up a port for attaching a remote debugging service using debugpy
 python -m debugpy --listen 0.0.0.0:5678 ./manage.py runserver 0.0.0.0:8000

--- a/app/deploy/docker-entrypoint.sh
+++ b/app/deploy/docker-entrypoint.sh
@@ -20,6 +20,6 @@ echo Apply migrations
 python manage.py migrate --noinput
 
 # echo Create root user
-# python manage.py shell -c "from apps.users.models import User; User.objects.create_superuser('admin@admin.com', 'admin')"
+# python manage.py shell -c "from django.contrib.auth import get_user_model; get_user_model().objects.create_superuser('admin@admin.com', 'admin')"
 celery -A config worker -l info -D
 exec uwsgi --ini /app/deploy/config.ini #--py-auto-reload=1

--- a/app/utils/unittest_helpers.py
+++ b/app/utils/unittest_helpers.py
@@ -1,5 +1,6 @@
 from apps.users.models import User
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -23,7 +24,7 @@ def get_test_user():
     """
     Creates and returns a test user
     """
-    return User.objects.get_or_create(email=AUTHENTICATED_CLIENT_EMAIL)[0]
+    return get_user_model().objects.get_or_create(email=AUTHENTICATED_CLIENT_EMAIL)[0]
 
 
 def get_authenticated_client():

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,6 +1,6 @@
 
 # Creates a superuser for the zaak-gateway backend
-echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin@admin.com', 'admin')" | docker-compose run --rm zaak-gateway python manage.py shell
+echo "from django.contrib.auth import get_user_model; get_user_model().objects.create_superuser('admin@admin.com', 'admin')" | docker-compose run --rm zaak-gateway python manage.py shell
 
 # Creates a superuser for the openzaak backend
-echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@admin.com', 'admin')" | docker-compose run --rm openzaak python src/manage.py shell
+echo "from django.contrib.auth import get_user_model; get_user_model().objects.create_superuser('admin', 'admin@admin.com', 'admin')" | docker-compose run --rm openzaak python src/manage.py shell


### PR DESCRIPTION
Instead of referencing the 'user' app User model, we should be using the Django get_user_model. If we ever decide to swap the User model in the future, this change will propagate automatically through the rest of the application.