### PR TITLE
Add superuser script and update README

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,4 @@
-# Set these in your .local.env file
+# Set these in your .env.local file
 BRP_CLIENT_ID=
 BRP_CLIENT_SECRET=
 SLACK_WEBHOOK_URL=

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - run: docker network create top_and_zaak_backend_bridge
       - run: docker compose -f docker-compose.local.yml up --detach
       - run: sleep 30
-      - run: bash bin/setup_credentials.sh
+      - run: bash bin/setup_superuser.sh admin@admin.com
       - run: ./e2e-tests/fix_models.sh
 
       ###################################################

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,12 @@
 __pycache__/
 .vscode/
 .DS_Store
-.env.local
 !**/src/main/**/build/
 !**/src/test/**/build/
 
 app/.env
 app/.coverage
 private_media/
+
+.env.local
 .local.env

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ sh bin/setup_superuser.sh <email>
 ```
 
 ### Using local development authentication
-To run the project with local Django authentication instead of OpenID Connect (OIDC), create a `.local.env` file with:
+To run the project with local Django authentication instead of OpenID Connect (OIDC), create a `.env.local` file with:
 
 ```bash
 LOCAL_DEVELOPMENT_AUTHENTICATION=False
@@ -118,26 +118,25 @@ http://localhost:8080/api/v1/swagger/
 
 ## Generating an access token
 
-When the LOCAL_DEVELOPMENT_AUTHENTICATION environment variable is set to True, you can gain access easily in the Swagger documentation by executing the /api/v1/oidc-authenticate/ POST request.
-You can use the 'access' token in the response:
+When the `LOCAL_DEVELOPMENT_AUTHENTICATION` environment variable is set to `True`, you can gain access easily in the Swagger documentation by executing the `/api/v1/oidc-authenticate/` POST request.
+
+You can use the 'access' token in the response: \
 Click on the 'Authorize' button in the top right corner of the page, and enter the given access token.
-This allows you to execute the API endpoints in the page.
+This allows you to execute the API endpoints in the page. \
 By default, the `local.user@dev.com` user doesn't have any roles assigned.
 From the [admin interface](http://localhost:8080/admin/) you can either assign roles or make the user superuser.
 
 ## Enabling local development environment variables
 
-Create a `.env.local` file, on the root of your project, and override the variables you need locally
-
-Start your project with the newly created environment variables, like so:
+Create a `.env.local` file, on the root of your project, and override the variables you need locally. This file is automatically loaded when you start the project:
 
 ```bash
-docker compose -f docker-compose.local.yml --env-file .env.local up
+docker compose -f docker-compose.local.yml up
 ```
 
 ## Enabling Keycloak authentication for a locally run zaken-frontend
 
-Set `LOCAL_DEVELOPMENT_AUTHENTICATION` by adding it to a `.local.env` file:
+Set `LOCAL_DEVELOPMENT_AUTHENTICATION` by adding it to a `.env.local` file:
 
 ```bash
 LOCAL_DEVELOPMENT_AUTHENTICATION=False

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Make sure you have Docker installed locally:
 
 These steps are necessary to make sure all configurations are set up correctly so that you can get the project running correctly.
 
-First, make sure you have built the project and executed the database migrations:
+### Creating networks & build container
+
+First, create the necessary networks and build the project:
 
 ```bash
 docker network create top_and_zaak_backend_bridge
@@ -45,29 +47,39 @@ docker network create zaken_network
 docker compose -f docker-compose.local.yml build
 ```
 
-Start AZA backend:
+### Starting the backend
+
+Run the following to start the backend:
 
 ```bash
 docker compose -f docker-compose.local.yml up
 ```
 
-To create all necessary credentials run the following command:
+### Creating a superuser
+
+For accessing the Django admin during local development you'll have to become a `superuser`. This user should have the same `email` and `username` as the one that will be auto-created by the SSO login.
+
+Run the following command to either create the user, or make the existing one a superuser:
 
 ```bash
-bash bin/setup_credentials.sh
+sh bin/setup_superuser.sh <email>
 ```
 
-This will create superuser admin account with the following credentials
+### Using local development authentication
+To run the project with local Django authentication instead of OpenID Connect (OIDC), create a `.local.env` file with:
 
 ```bash
-email: admin@admin.com
-password: insecure
+LOCAL_DEVELOPMENT_AUTHENTICATION=False
 ```
 
-Visit the Admin at http://localhost:8080/admin/
+### Django admin & services
+
+Visit the Admin at http://localhost:8081/admin/
 
 Check the health page to see if all services are up and running:
 http://localhost:8080/health
+
+### Creating user groups
 
 To create all necessary user groups run the following command:
 
@@ -125,7 +137,11 @@ docker compose -f docker-compose.local.yml --env-file .env.local up
 
 ## Enabling Keycloak authentication for a locally run zaken-frontend
 
-Set `LOCAL_DEVELOPMENT_AUTHENTICATION` environment variable to False
+Set `LOCAL_DEVELOPMENT_AUTHENTICATION` by adding it to a `.local.env` file:
+
+```bash
+LOCAL_DEVELOPMENT_AUTHENTICATION=False
+```
 
 ## Generating Mock Data
 

--- a/bin/setup_credentials.sh
+++ b/bin/setup_credentials.sh
@@ -1,2 +1,0 @@
-# Creates a superuser for the zaak-gateway backend
-echo "from django.contrib.auth import get_user_model; get_user_model().objects.create_superuser('admin@admin.com', 'insecure')" | docker compose -f docker-compose.local.yml run -T --rm zaak-gateway python manage.py shell

--- a/bin/setup_superuser.sh
+++ b/bin/setup_superuser.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Creates a superuser for the given `email` address, or updates if it already exists.
+#
+# Example usage:
+# ./bin/setup_superuser.sh user@amsterdam.nl
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <email>"
+    exit 1
+fi
+
+WEB_SERVICE_NAME="zaak-gateway"
+EMAIL="$1"
+
+docker compose -f docker-compose.local.yml run -T --rm "${WEB_SERVICE_NAME}" python manage.py shell <<PY
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+email = "${EMAIL}"
+
+user, created = User.objects.get_or_create(email=email, username=email)
+
+user.is_staff = True
+user.is_superuser = True
+user.is_active = True
+
+user.save()
+
+print(f"{'Created' if created else 'Updated'} superuser for {email}")
+PY

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -36,6 +36,8 @@ services:
       - zaak-redis
     env_file:
       - path: .env
+      - path: .env.local
+        required: false
       - path: .local.env
         required: false
     entrypoint: /app/deploy/docker-entrypoint.development.sh

--- a/e2e-tests/setup_or_reset_and_start.sh
+++ b/e2e-tests/setup_or_reset_and_start.sh
@@ -8,7 +8,7 @@ docker compose -f ../docker-compose.local.yml build
 
 docker compose run --rm zaak-gateway python manage.py migrate
 
-bash ../bin/setup_credentials.sh
+bash ../bin/setup_superuser.sh admin@admin.com
 
 ./fix_models.sh
 


### PR DESCRIPTION
- Same change as `top-backend`;
- Added a note about locally adding `LOCAL_DEVELOPMENT_AUTHENTICATION`.

---

Previous changes from `top-backend`:

Created a simple script which should tackle the SSO issues I had the other day when setting up projects and creating a superuser.

So this is to ensure that whatever you do first, the SSO-created user always aligns with creating or updating a superuser.

Scenarios tested:

✅ No user -> run this command (creates a superuser) -> visit the admin + loggin in via SSO;
✅ No user -> visit the frontend (which creates a user via SSO) -> run this command (upgrades to superuser) -> visit the admin;
✅ Existing user -> run this command (upgrades to super) (this is more or less the above scenario, given that the user was created via SSO and the username/email matches...)

Feedback or alternative solutions are welcome. If it looks good, we can implement it in other projects as well 👋