### PR TITLE
Increase BAG benkagg timeout and remove retry decorator

### DIFF
--- a/app/apps/health/health_checks.py
+++ b/app/apps/health/health_checks.py
@@ -171,7 +171,7 @@ class Belastingdienst(BaseHealthCheckBackend):
         from apps.fines.api_queries_belastingen import get_fines
 
         try:
-            # The id doesn't matter, as long an authenticated request is succesful.
+            # The id doesn't matter, as long an authenticated request is successful.
             get_fines("foo-id", use_retry=False)
         except SSLError as e:
             logger.error(e)

--- a/app/utils/api_queries_bag.py
+++ b/app/utils/api_queries_bag.py
@@ -7,7 +7,6 @@ from tenacity import after_log, retry, stop_after_attempt
 logger = logging.getLogger(__name__)
 
 
-@retry(stop=stop_after_attempt(3), after=after_log(logger, logging.ERROR))
 def do_bag_search_benkagg_by_id(identificatie):
     """
     Search BAG by identificatie (nummeraanduiding_id).
@@ -19,8 +18,9 @@ def do_bag_search_benkagg_by_id(identificatie):
     address_search = requests.get(
         settings.BAG_API_BENKAGG_SEARCH_URL,
         params={"identificatie": identificatie},
-        timeout=30,
+        timeout=50,
     )
+
     return address_search.json()
 
 


### PR DESCRIPTION
- Increate timeout due to slow API, but remove `@retry` decorator, allowing for longer calls, but staying withint <60s server timeout (instead of 3x30s = 90s)