### PR TITLE
Add CaseAddressSerializer and update AddressViewSet to limit sensitiv…

### DIFF
--- a/app/apps/addresses/tests/tests_api.py
+++ b/app/apps/addresses/tests/tests_api.py
@@ -2,6 +2,7 @@ import datetime
 
 from apps.addresses.models import Address
 from apps.cases.models import Case
+from django.contrib.auth import get_user_model
 from django.core import management
 from django.urls import reverse
 from model_bakery import baker
@@ -109,12 +110,12 @@ class AddressCasesApiTest(APITestCase):
 
         self.assertEqual(len(data["results"]), NUMBER_OF_CLOSED_CASES)
 
-    def test_authenticated_get_includes_sensitive_cases(self):
+    def test_authenticated_get_includes_sensitive_cases_without_permission(self):
         """
-        DELIBERATE DESIGN: users without the `users.access_sensitive_dossiers`
+        DELIBERATE DESIGN: users WITHOUT the `users.access_sensitive_dossiers`
         permission should still see THAT sensitive cases exist on an address
         (so they know what is going on at the address), but only with the
-        limited field set of CaseAddressSerializer. Detail access to
+        limited field set of AddressCaseListSerializer. Detail access to
         sensitive cases remains restricted via CaseViewSet.
         """
         BAG_ID = "foo"
@@ -123,21 +124,24 @@ class AddressCasesApiTest(APITestCase):
         baker.make(Case, address=address, sensitive=True)
         baker.make(Case, address=address, sensitive=False)
 
+        user = baker.make(get_user_model())
+        self.assertFalse(user.has_perm("users.access_sensitive_dossiers"))
+
         url = reverse("addresses-cases", kwargs={"bag_id": BAG_ID})
-        client = get_authenticated_client()
-        response = client.get(url)
+        self.client.force_authenticate(user=user)
+        response = self.client.get(url)
         data = response.json()
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(data["results"]), 2)
 
-    def test_authenticated_get_returns_only_limited_fields(self):
+    def test_authenticated_get_returns_only_limited_fields_without_permission(self):
         """
         The address endpoint must never expose the full CaseSerializer
-        representation. Only this limited field set is allowed, so that
-        details of sensitive cases do not leak to users without the
-        `users.access_sensitive_dossiers` permission. Do not add fields
-        here without reviewing what they reveal about sensitive cases.
+        representation to users without the `users.access_sensitive_dossiers`
+        permission. Only this limited field set is allowed, so that details
+        of sensitive cases do not leak. Do not add fields here without
+        reviewing what they reveal about sensitive cases.
         """
         BAG_ID = "foo"
         EXPECTED_FIELDS = {
@@ -153,9 +157,12 @@ class AddressCasesApiTest(APITestCase):
         address = baker.make(Address, bag_id=BAG_ID)
         baker.make(Case, address=address, sensitive=True)
 
+        user = baker.make(get_user_model())
+        self.assertFalse(user.has_perm("users.access_sensitive_dossiers"))
+
         url = reverse("addresses-cases", kwargs={"bag_id": BAG_ID})
-        client = get_authenticated_client()
-        response = client.get(url)
+        self.client.force_authenticate(user=user)
+        response = self.client.get(url)
         data = response.json()
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/app/apps/addresses/tests/tests_api.py
+++ b/app/apps/addresses/tests/tests_api.py
@@ -108,3 +108,55 @@ class AddressCasesApiTest(APITestCase):
         data = response.json()
 
         self.assertEqual(len(data["results"]), NUMBER_OF_CLOSED_CASES)
+
+    def test_authenticated_get_includes_sensitive_cases(self):
+        """
+        DELIBERATE DESIGN: users without the `users.access_sensitive_dossiers`
+        permission should still see THAT sensitive cases exist on an address
+        (so they know what is going on at the address), but only with the
+        limited field set of CaseAddressSerializer. Detail access to
+        sensitive cases remains restricted via CaseViewSet.
+        """
+        BAG_ID = "foo"
+
+        address = baker.make(Address, bag_id=BAG_ID)
+        baker.make(Case, address=address, sensitive=True)
+        baker.make(Case, address=address, sensitive=False)
+
+        url = reverse("addresses-cases", kwargs={"bag_id": BAG_ID})
+        client = get_authenticated_client()
+        response = client.get(url)
+        data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data["results"]), 2)
+
+    def test_authenticated_get_returns_only_limited_fields(self):
+        """
+        The address endpoint must never expose the full CaseSerializer
+        representation. Only this limited field set is allowed, so that
+        details of sensitive cases do not leak to users without the
+        `users.access_sensitive_dossiers` permission. Do not add fields
+        here without reviewing what they reveal about sensitive cases.
+        """
+        BAG_ID = "foo"
+        EXPECTED_FIELDS = {
+            "id",
+            "advertisements",
+            "start_date",
+            "end_date",
+            "theme",
+            "workflows",
+            "reason",
+        }
+
+        address = baker.make(Address, bag_id=BAG_ID)
+        baker.make(Case, address=address, sensitive=True)
+
+        url = reverse("addresses-cases", kwargs={"bag_id": BAG_ID})
+        client = get_authenticated_client()
+        response = client.get(url)
+        data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(set(data["results"][0].keys()), EXPECTED_FIELDS)

--- a/app/apps/addresses/views.py
+++ b/app/apps/addresses/views.py
@@ -12,7 +12,8 @@ from apps.addresses.serializers import (
     RegistrationNumberSerializer,
 )
 from apps.cases.models import Advertisement
-from apps.cases.serializers import AdvertisementSerializer, CaseSerializer
+from apps.cases.serializers import AdvertisementSerializer
+from apps.cases.serializers.case import CaseAddressSerializer
 from apps.permits.mixins import PermitDetailsMixin
 from apps.users import permissions
 from drf_spectacular.types import OpenApiTypes
@@ -120,13 +121,17 @@ class AddressViewSet(
 
     @extend_schema(
         parameters=[open_cases],
-        description="Get cases for given BAG ID",
-        responses={200: CaseSerializer(many=True)},
+        description=(
+            "Get cases for given BAG ID. Returns a deliberately limited field "
+            "set: users without `users.access_sensitive_dossiers` may see that "
+            "(sensitive) cases exist on an address, but not their details."
+        ),
+        responses={200: CaseAddressSerializer(many=True)},
     )
     @action(
         detail=True,
         methods=["get"],
-        serializer_class=CaseSerializer,
+        serializer_class=CaseAddressSerializer,
         url_path="cases",
     )
     def cases(self, request, bag_id, **kwargs):
@@ -147,7 +152,7 @@ class AddressViewSet(
 
             paginator = LimitOffsetPagination()
             context = paginator.paginate_queryset(query_set, request)
-            serializer = CaseSerializer(context, many=True)
+            serializer = CaseAddressSerializer(context, many=True)
 
             return paginator.get_paginated_response(serializer.data)
 

--- a/app/apps/addresses/views.py
+++ b/app/apps/addresses/views.py
@@ -13,7 +13,7 @@ from apps.addresses.serializers import (
 )
 from apps.cases.models import Advertisement
 from apps.cases.serializers import AdvertisementSerializer
-from apps.cases.serializers.case import CaseAddressSerializer
+from apps.cases.serializers.case import AddressCaseListSerializer
 from apps.permits.mixins import PermitDetailsMixin
 from apps.users import permissions
 from drf_spectacular.types import OpenApiTypes
@@ -126,12 +126,12 @@ class AddressViewSet(
             "set: users without `users.access_sensitive_dossiers` may see that "
             "(sensitive) cases exist on an address, but not their details."
         ),
-        responses={200: CaseAddressSerializer(many=True)},
+        responses={200: AddressCaseListSerializer(many=True)},
     )
     @action(
         detail=True,
         methods=["get"],
-        serializer_class=CaseAddressSerializer,
+        serializer_class=AddressCaseListSerializer,
         url_path="cases",
     )
     def cases(self, request, bag_id, **kwargs):
@@ -152,7 +152,7 @@ class AddressViewSet(
 
             paginator = LimitOffsetPagination()
             context = paginator.paginate_queryset(query_set, request)
-            serializer = CaseAddressSerializer(context, many=True)
+            serializer = AddressCaseListSerializer(context, many=True)
 
             return paginator.get_paginated_response(serializer.data)
 

--- a/app/apps/cases/serializers/case.py
+++ b/app/apps/cases/serializers/case.py
@@ -285,3 +285,38 @@ class CaseBagIdsSerializer(serializers.ModelSerializer):
             "bag_id",
             "nummeraanduiding_id",
         )
+
+
+class CaseAddressSerializer(serializers.ModelSerializer):
+    """
+    Beperkte zaak-weergave, uitsluitend voor het adres-endpoint
+    (AddressViewSet.cases).
+
+    BEWUSTE KEUZE: medewerkers zonder het recht
+    `users.access_sensitive_dossiers` mogen op adresniveau zien
+    dat er zaken (incl. sensitive) lopen, maar niet de details. Daarom
+    bevat deze serializer alleen een minimale veldenset. Voeg hier geen
+    velden toe zonder te toetsen of die informatie over sensitive zaken
+    mag lekken naar gebruikers zonder dat recht. Detailtoegang blijft
+    afgeschermd via CaseViewSet.get_queryset (exclude sensitive) en
+    CanAccessSensitiveCases.
+    """
+
+    advertisements = AdvertisementSerializer(many=True, required=False)
+    reason = CaseReasonSerializer(read_only=True)
+    theme = CaseThemeSerializer(read_only=True)
+    workflows = CaseWorkflowBaseSerializer(
+        source="get_workflows", many=True, read_only=True
+    )
+
+    class Meta:
+        model = Case
+        fields = (
+            "id",
+            "advertisements",
+            "start_date",
+            "end_date",
+            "theme",
+            "workflows",
+            "reason",
+        )

--- a/app/apps/cases/serializers/case.py
+++ b/app/apps/cases/serializers/case.py
@@ -287,7 +287,7 @@ class CaseBagIdsSerializer(serializers.ModelSerializer):
         )
 
 
-class CaseAddressSerializer(serializers.ModelSerializer):
+class AddressCaseListSerializer(serializers.ModelSerializer):
     """
     Beperkte zaak-weergave, uitsluitend voor het adres-endpoint
     (AddressViewSet.cases).


### PR DESCRIPTION
…e case exposure

- Introduced CaseAddressSerializer for restricted case representation at the address endpoint.
- Updated AddressViewSet to use CaseAddressSerializer, ensuring users without access to sensitive dossiers can see that cases exist without revealing details.
- Added tests to verify that sensitive cases are included in the response but only limited fields are exposed.